### PR TITLE
Feat/add es endpoint

### DIFF
--- a/handler/aws.go
+++ b/handler/aws.go
@@ -27,6 +27,11 @@ func init() {
 		host := fmt.Sprintf("execute-api.%s.amazonaws.com", region)
 		services[host] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host), SigningMethod: "v4", SigningRegion: region, SigningName: "execute-api"}
 	}
+	// Add elasticsearch endpoints
+	for region := range endpoints.AwsPartition().Regions() {
+		host := fmt.Sprintf("%s.es.amazonaws.com", region)
+		services[host] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host), SigningMethod: "v4", SigningRegion: region, SigningName: "es"}
+	}
 }
 
 func determineAWSServiceFromHost(host string) *endpoints.ResolvedEndpoint {

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -66,7 +66,7 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	proxyReq.Header = req.Header
 	service := determineAWSServiceFromHost(req.Host)
 	if service == nil {
 		return nil, fmt.Errorf("unable to determine service from host: %s", req.Host)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- extend the proxy to be use for aws elasticsearch
- added es endpoint to resolve service name
- es need other http headers(e.g. kbn-version(or kbn-xsrf will be required)) for normal use
- there might be 304 response from es, `http.StatusCode = 200` seems too strict, so I change that to be use for debugging >= 400 http error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
