### PR TITLE
feat: add s3 regional endpoints to resove bucket name host

### DIFF
--- a/handler/aws.go
+++ b/handler/aws.go
@@ -27,6 +27,15 @@ func init() {
 		host := fmt.Sprintf("execute-api.%s.amazonaws.com", region)
 		services[host] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host), SigningMethod: "v4", SigningRegion: region, SigningName: "execute-api"}
 	}
+
+	// Add s3 endpoints
+	for region := range endpoints.AwsPartition().Regions() {
+		formats := []string{"s3-%s.amazonaws.com", "s3.%s.amazonaws.com"}
+		for _, format := range formats {
+			host := fmt.Sprintf(format, region)
+			services[host] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host), SigningMethod: "v4", SigningRegion: region, SigningName: "s3"}
+		}
+	}
 }
 
 func determineAWSServiceFromHost(host string) *endpoints.ResolvedEndpoint {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- allow to use s3 service endpoints region and bucket name for signing s3 request

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
