### PR TITLE
Fixes typo in README for S3 us-east-1 curl request example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker run --rm -ti \
 S3
 ```
 # us-east-1
-curl -s -H 'host: s3.us-west-2.amazonaws.com' http://localhost:8080/<BUCKET_NAME>
+curl -s -H 'host: s3.amazonaws.com' http://localhost:8080/<BUCKET_NAME>
 
 # other region
 curl -s -H 'host: s3.<BUCKET_REGION>.amazonaws.com' http://localhost:8080/<BUCKET_NAME>


### PR DESCRIPTION
*Description of changes:*

Modified the curl request to remove the us-west-2 portion of the uri in the README.  I believe the intent was to show you can query the us-east-1 buckets by having no region in the uri

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
