### PR TITLE
Ecs task role credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,6 @@ package main
 
 import (
 	"net/http"
-
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/awslabs/aws-sigv4-proxy/handler"
   "github.com/aws/aws-sdk-go/aws/defaults"
@@ -19,32 +14,6 @@ var (
 	port  = kingpin.Flag("port", "port to serve http on").Default(":8080").String()
 )
 
-func getCredentials() (*credentials.Credentials, error) {
-	// Check env var, shared credentials, then finally ec2 instance role
-	providers := []credentials.Provider{
-		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{},
-		&ec2rolecreds.EC2RoleProvider{
-			Client: ec2metadata.New(session.Must(session.NewSession())),
-		},
-	}
-
-  // If ECS task role endpoint is available add ECS task role to provider chain
-  if uri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"); len(uri) > 0 {
-    // Just create a default remote client for this?
-    providers = append(providers, defaults.RemoteCredProvider(&aws.Config{}, defaults.Handlers()))
-    log.Print("Remote cred provider added because ECS relative URI found")
-  }
-
-	creds := credentials.NewChainCredentials(providers)
-
-	if _, err := creds.Get(); err != nil {
-		return nil, err
-	}
-
-	return creds, nil
-}
-
 func main() {
 	kingpin.Parse()
 
@@ -53,10 +22,8 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	creds, err := getCredentials()
-	if err != nil {
-		log.WithError(err).Fatal("unable to get credentials")
-	}
+  cfg := defaults.Get().Config
+  creds := cfg.Credentials
 
 	signer := v4.NewSigner(creds)
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/awslabs/aws-sigv4-proxy/handler"
-	log "github.com/sirupsen/logrus"
+  "github.com/aws/aws-sdk-go/aws/defaults"
+  log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -27,6 +28,13 @@ func getCredentials() (*credentials.Credentials, error) {
 			Client: ec2metadata.New(session.Must(session.NewSession())),
 		},
 	}
+
+  // If ECS task role endpoint is available add ECS task role to provider chain
+  if uri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"); len(uri) > 0 {
+    // Just create a default remote client for this?
+    providers = append(providers, defaults.RemoteCredProvider(&aws.Config{}, defaults.Handlers()))
+    log.Print("Remote cred provider added because ECS relative URI found")
+  }
 
 	creds := credentials.NewChainCredentials(providers)
 


### PR DESCRIPTION
*Description of changes:*

The existing implementation for gathering credentials uses a static set of 3 different credential providers.  If you want to use something outside of the 3 assembled credential providers you're stuck.  This change switches to just using the aws sdk default method for gathering configuration and credentials.  It now passes those credentials to the sigv4 sign method.

This should provide greater flexibility in terms of the types of credential providers being used.  Simply upgrading the aws sdk should add anything they have added to the default cred chain as well.  It also simplifies the amount of code needed and reduces necessary imports.

Incidentally this also fixes the problem of being unable to run this in a fargate task and have it use the ECS task role for its credentials.  



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
