### PR TITLE
Reworks how credentials are acquired so it uses the aws sdk default c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # AWS SigV4 Proxy
 
-The AWS SigV4 Proxy will sign incoming HTTP requests and forward them to the host specified in the `Host` header.  
+The AWS SigV4 Proxy will sign incoming HTTP requests and forward them to the host specified in the `Host` header.
 
 ## Getting Started
 
 Build and run the Proxy
 
 ```go
-* The proxy will try to find credentials in the environment, shared credentials file, then the ec2 instance
+The proxy uses the default AWS SDK for Go credential search path:
+
+* Environment variables.
+* Shared credentials file.
+* IAM role for Amazon EC2 or ECS task role
+
+More information can be found in the [developer guide](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)
 
 docker build -t aws-sigv4-proxy .
 
@@ -17,8 +23,6 @@ docker run --rm -ti \
   -e 'AWS_SECRET_ACCESS_KEY=<YOUR SECRET ACCESS KEY>' \
   -p 8080:8080 \
   aws-sigv4-proxy -v
-
-***** or ******
 
 # Shared Credentials
 docker run --rm -ti \
@@ -56,4 +60,4 @@ curl -H 'host: <REST_API_ID>.execute-api.<AWS_REGION>.amazonaws.com' http://loca
 
 ## License
 
-This library is licensed under the Apache 2.0 License. 
+This library is licensed under the Apache 2.0 License.

--- a/main.go
+++ b/main.go
@@ -22,10 +22,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	cfg := defaults.Get().Config
-	creds := cfg.Credentials
-
-	signer := v4.NewSigner(creds)
+	signer := v4.NewSigner(defaults.Get().Config.Credentials)
 
 	log.WithFields(log.Fields{"port": *port}).Infof("Listening on %s", *port)
 

--- a/main.go
+++ b/main.go
@@ -2,13 +2,9 @@ package main
 
 import (
 	"net/http"
-
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/awslabs/aws-sigv4-proxy/handler"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -18,25 +14,6 @@ var (
 	port  = kingpin.Flag("port", "port to serve http on").Default(":8080").String()
 )
 
-func getCredentials() (*credentials.Credentials, error) {
-	// Check env var, shared credentials, then finally ec2 instance role
-	providers := []credentials.Provider{
-		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{},
-		&ec2rolecreds.EC2RoleProvider{
-			Client: ec2metadata.New(session.Must(session.NewSession())),
-		},
-	}
-
-	creds := credentials.NewChainCredentials(providers)
-
-	if _, err := creds.Get(); err != nil {
-		return nil, err
-	}
-
-	return creds, nil
-}
-
 func main() {
 	kingpin.Parse()
 
@@ -45,10 +22,8 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	creds, err := getCredentials()
-	if err != nil {
-		log.WithError(err).Fatal("unable to get credentials")
-	}
+	cfg := defaults.Get().Config
+	creds := cfg.Credentials
 
 	signer := v4.NewSigner(creds)
 


### PR DESCRIPTION
*Description of changes:*

The existing implementation for gathering credentials uses a static set of 3 different credential providers. If you want to use something outside of the 3 assembled credential providers you're stuck. This change switches to just using the aws sdk default method for gathering configuration and credentials. It now passes those credentials to the sigv4 sign method.

This should provide greater flexibility in terms of the types of credential providers being used. Simply upgrading the aws sdk should add anything they have added to the default cred chain as well. It also simplifies the amount of code needed and reduces necessary imports.

Incidentally this also fixes the problem of being unable to run this in a fargate task and have it use the ECS task role for its credentials.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
