### PR TITLE
Adds functionality to strip out headers from incoming requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The AWS SigV4 Proxy will sign incoming HTTP requests and forward them to the host specified in the `Host` header.
 
+You can strip out arbirtary headers from the incoming request by using the -s option.
+
 ## Getting Started
 
 Build and run the Proxy
@@ -30,6 +32,13 @@ docker run --rm -ti \
   -p 8080:8080 \
   -e 'AWS_PROFILE=<SOME PROFILE>' \
   aws-sigv4-proxy -v
+
+# Stripping out old Sigv2 authorization headers
+docker run --rm -ti \
+  -v ~/.aws:/root/.aws \
+  -p 8080:8080 \
+  -e 'AWS_PROFILE=<SOME PROFILE>' \
+  aws-sigv4-proxy -v -s Authorization
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ docker run --rm -ti \
   -p 8080:8080 \
   -e 'AWS_PROFILE=<SOME PROFILE>' \
   aws-sigv4-proxy -v
-
-# Stripping out old Sigv2 authorization headers
-docker run --rm -ti \
-  -v ~/.aws:/root/.aws \
-  -p 8080:8080 \
-  -e 'AWS_PROFILE=<SOME PROFILE>' \
-  aws-sigv4-proxy -v -s Authorization
 ```
 
 ## Examples
@@ -60,6 +53,15 @@ curl -s -H 'host: sqs.<AWS_REGION>.amazonaws.com' 'http://localhost:8080/<AWS_AC
 API Gateway
 ```sh
 curl -H 'host: <REST_API_ID>.execute-api.<AWS_REGION>.amazonaws.com' http://localhost:8080/<STAGE>/<PATH>
+```
+
+Running the service and stripping out sigv2 authorization headers
+```sh
+docker run --rm -ti \
+  -v ~/.aws:/root/.aws \
+  -p 8080:8080 \
+  -e 'AWS_PROFILE=<SOME PROFILE>' \
+  aws-sigv4-proxy -v -s Authorization
 ```
 
 ## Reference

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -23,6 +23,7 @@ type ProxyClient struct {
 	Signer *v4.Signer
 	Client Client
 	Region string
+	Strip []string
 }
 
 func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoint) error {
@@ -72,6 +73,14 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 	proxyURL.Host = req.Host
 	proxyURL.Scheme = "https"
 
+	if log.GetLevel() == log.DebugLevel {
+		initialReqDump, err := httputil.DumpRequest(req, true)
+		if err != nil {
+			log.WithError(err).Error("unable to dump request")
+		}
+		log.WithField("request", string(initialReqDump)).Debug("Initial request dump:")
+	}
+
 	proxyReq, err := http.NewRequest(req.Method, proxyURL.String(), req.Body)
 	if err != nil {
 		return nil, err
@@ -84,6 +93,12 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 
 	if err := p.sign(proxyReq, service); err != nil {
 		return nil, err
+	}
+
+	// Remove any headers specified
+	for _, header := range p.Strip {
+		log.WithField("StripHeader", string(header)).Debug("Stripping Header:")
+		req.Header.Del(header)
 	}
 
 	// Add origin headers after request is signed (no overwrite)

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -23,7 +23,7 @@ type ProxyClient struct {
 	Signer *v4.Signer
 	Client Client
 	Region string
-	Strip []string
+	StripRequestHeaders []string
 }
 
 func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoint) error {
@@ -96,7 +96,7 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	// Remove any headers specified
-	for _, header := range p.Strip {
+	for _, header := range p.StripRequestHeaders {
 		log.WithField("StripHeader", string(header)).Debug("Stripping Header:")
 		req.Header.Del(header)
 	}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 var (
 	debug = kingpin.Flag("verbose", "enable additional logging").Short('v').Bool()
 	port  = kingpin.Flag("port", "port to serve http on").Default(":8080").String()
+	strip = kingpin.Flag("strip", "Headers to strip from incoming request").Short('s').Strings()
 )
 
 func main() {
@@ -24,6 +25,7 @@ func main() {
 
 	signer := v4.NewSigner(defaults.Get().Config.Credentials)
 
+	log.WithFields(log.Fields{"StripHeaders": *strip}).Infof("Stripping headers %s", *strip)
 	log.WithFields(log.Fields{"port": *port}).Infof("Listening on %s", *port)
 
 	log.Fatal(
@@ -31,6 +33,7 @@ func main() {
 			ProxyClient: &handler.ProxyClient{
 				Signer: signer,
 				Client: http.DefaultClient,
+				Strip: *strip,
 			},
 		}),
 	)

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 			ProxyClient: &handler.ProxyClient{
 				Signer: signer,
 				Client: http.DefaultClient,
-				Strip: *strip,
+				StripRequestHeaders: *strip,
 			},
 		}),
 	)


### PR DESCRIPTION
*Description of changes:*
Adds a -s (--strip) flag, which is repeatable. All headers from the incoming
request that match (case insensitive) will be removed.

Adds additional debug logging for this feature.

_This is especially useful if you have old sigv2 requests you want to be
able to send through the proxy.  If you do not remove the "Authorization" header
that exists you will get a 400 bad request._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
