### PR TITLE
S3-specific non-escaping signer

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -21,6 +21,7 @@ type Client interface {
 // ProxyClient implements the Client interface
 type ProxyClient struct {
 	Signer *v4.Signer
+	S3Signer *v4.Signer
 	Client Client
 	Region string
 	StripRequestHeaders []string
@@ -44,7 +45,7 @@ func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoin
 		_, err = p.Signer.Sign(req, body, service.SigningName, service.SigningRegion, time.Now())
 		break
 	case "s3":
-		_, err = p.Signer.Presign(req, body, service.SigningName, service.SigningRegion, time.Duration(time.Hour), time.Now())
+		_, err = p.S3Signer.Presign(req, body, service.SigningName, service.SigningRegion, time.Duration(time.Hour), time.Now())
 		break
 	default:
 		err = fmt.Errorf("unable to sign with specified signing method %s for service %s", service.SigningMethod, service.SigningName)

--- a/handler/proxy_client_test.go
+++ b/handler/proxy_client_test.go
@@ -138,7 +138,7 @@ func TestProxyClient_Do(t *testing.T) {
 			},
 		},
 		{
-			name: "should return request when everything 👍 (presign codepath)",
+			name: "should return request when everything 👍 (s3/presign codepath)",
 			request: &http.Request{
 				Method: "GET",
 				URL:    &url.URL{},
@@ -146,7 +146,7 @@ func TestProxyClient_Do(t *testing.T) {
 				Body:   nil,
 			},
 			proxyClient: &ProxyClient{
-				Signer: v4.NewSigner(credentials.NewCredentials(&mockProvider{})),
+				S3Signer: v4.NewSigner(credentials.NewCredentials(&mockProvider{})),
 				Region: "us-west-2",
 				Client: &mockHTTPClient{},
 			},


### PR DESCRIPTION
*Issue #, if available:*
#11 

*Description of changes:*
As S3 URI paths should not be escaped within a signature, the S3 signing case cannot use the same signer instance as the general case (since URI path escaping is a field of the signer and not a
per-signature parameter).  This adds an `S3Signer` method to the proxy client and applies it appropriately.

I didn't see an obvious good way to expand the unit tests for this case, since the tests are operating at a higher level than the details involved here.  So I adjusted the presign use case to account for the new `S3Signer` field; the test will fail if the `S3Signer` isn't present.  It's not optimal but it's more than nothing.

Note that while I believe this addresses part of what #11 identified, I think there's a separate problem (also related to URI path encoding) that has to be additionally addressed (if an encoded non-canonical form of a path is given, the resulting proxy signature will be invalid).  My intention is to file a separate issue for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.