### PR TITLE
Add overrides for signing name, region, and host

### DIFF
--- a/handler/aws.go
+++ b/handler/aws.go
@@ -40,6 +40,6 @@ func determineAWSServiceFromHost(host string) *endpoints.ResolvedEndpoint {
 			return &service
 		}
 	}
-
 	return nil
 }
+

--- a/main.go
+++ b/main.go
@@ -13,6 +13,9 @@ var (
 	debug = kingpin.Flag("verbose", "enable additional logging").Short('v').Bool()
 	port  = kingpin.Flag("port", "port to serve http on").Default(":8080").String()
 	strip = kingpin.Flag("strip", "Headers to strip from incoming request").Short('s').Strings()
+	signingNameOverride = kingpin.Flag("name", "AWS Service to sign for").String();
+	hostOverride = kingpin.Flag("host", "Host to proxy to").String();
+	regionOverride = kingpin.Flag("region", "AWS region to sign for").String();
 )
 
 func main() {
@@ -34,6 +37,9 @@ func main() {
 				Signer: signer,
 				Client: http.DefaultClient,
 				StripRequestHeaders: *strip,
+				SigningNameOverride: *signingNameOverride,
+				HostOverride: *hostOverride,
+				RegionOverride: *regionOverride,
 			},
 		}),
 	)


### PR DESCRIPTION
*Issue #, if available:* Builds on top of https://github.com/awslabs/aws-sigv4-proxy/pull/2

*Description of changes:*

* Use cli parameter to determine whether a host is to be overriden
* Use cli parameter to override region, and service name. This is useful for https://github.com/awslabs/aws-sigv4-proxy/issues/14


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
