### PR TITLE
Bug fix: HTTP Response returns an empty body when error occurs

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,6 +34,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if log.GetLevel() == log.DebugLevel && resp.StatusCode >= 400 {
+		log.WithField("message", buf.String()).Error("error proxying request")
+	}
+
 	// copy headers
 	for k, vals := range resp.Header {
 		for _, v := range vals {

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -20,12 +20,12 @@ type Client interface {
 
 // ProxyClient implements the Client interface
 type ProxyClient struct {
-	Signer *v4.Signer
-	Client Client
+	Signer              *v4.Signer
+	Client              Client
 	StripRequestHeaders []string
 	SigningNameOverride string
-	HostOverride string
-	RegionOverride string
+	HostOverride        string
+	RegionOverride      string
 }
 
 func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoint) error {
@@ -127,11 +127,6 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 	resp, err := p.Client.Do(proxyReq)
 	if err != nil {
 		return nil, err
-	}
-
-	if log.GetLevel() == log.DebugLevel && resp.StatusCode >= 400 {
-		b, _ := ioutil.ReadAll(resp.Body)
-		log.WithField("message", string(b)).Error("error proxying request")
 	}
 
 	return resp, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since we already read the data in io.ReadAll, the resp.Body no longer has any data to be read. We cannot go back and re-read Body data we have already consumed with a read.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
