### PR TITLE
Return 502 instead of 400 when calling upstream service failed

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -2,7 +2,8 @@ package handler
 
 import (
 	"bytes"
-	"io"
+    "fmt"
+    "io"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -20,8 +21,9 @@ func (h *Handler) write(w http.ResponseWriter, status int, body []byte) {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.ProxyClient.Do(r)
 	if err != nil {
-		log.WithError(err).Error("unable to proxy request")
-		h.write(w, http.StatusBadRequest, []byte(err.Error()))
+	    errorMsg := "unable to proxy request"
+		log.WithError(err).Error(errorMsg)
+		h.write(w, http.StatusBadGateway, []byte(fmt.Sprintf("%v - %v", errorMsg, err.Error())))
 		return
 	}
 	defer resp.Body.Close()
@@ -29,8 +31,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// read response body
 	buf := bytes.Buffer{}
 	if _, err := io.Copy(&buf, resp.Body); err != nil {
-		log.WithError(err).Error("unable to proxy request")
-		h.write(w, http.StatusInternalServerError, []byte(err.Error()))
+	    errorMsg := "error while reading response from upstream"
+		log.WithError(err).Error(errorMsg)
+		h.write(w, http.StatusInternalServerError, []byte(fmt.Sprintf("%v - %v", errorMsg, err.Error())))
 		return
 	}
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -37,14 +37,14 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		want    *want
 	}{
 		{
-			name: "responds with 400 if proxy request fails",
+			name: "responds with 502 if proxy request fails",
 			handler: &Handler{
 				ProxyClient: &mockProxyClient{Fail: true},
 			},
 			request: &http.Request{},
 			want: &want{
-				statusCode: http.StatusBadRequest,
-				body:       []byte(`mockProxyClient.Do failed`),
+				statusCode: http.StatusBadGateway,
+				body:       []byte(`unable to proxy request - mockProxyClient.Do failed`),
 				header:     http.Header{},
 			},
 		},


### PR DESCRIPTION
*Description of changes:*
HTTP 502 is better status, as according to HTTP RFC, to return when calling upstream service failed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
