### PR TITLE
Update README for service name & region overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ docker run --rm -ti \
   aws-sigv4-proxy -v --role-arn <ARN OF ROLE TO ASSUME>
 ```
 
+Include service name & region overrides when you notice errors like `unable to determine service from host` for API gateway, for example.
+```sh
+docker run --rm -ti \
+  -v ~/.aws:/root/.aws \
+  -p 8080:8080 \
+  -e 'AWS_PROFILE=<SOME PROFILE>' \
+  aws-sigv4-proxy -v --name execute-api --region us-east-1
+```
+
 ## Reference
 
 - [AWS SigV4 Signing Docs ](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)


### PR DESCRIPTION
Adding an example for overriding service name & region values when API gateway calls return unable to determine service from host error. 

Issue: https://github.com/awslabs/aws-sigv4-proxy/issues/29

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
