### PR TITLE
Disable redirect handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,11 @@ func main() {
 			s.Debug = aws.LogDebugWithSigning
 		}
 	})
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 
 	log.WithFields(log.Fields{"StripHeaders": *strip}).Infof("Stripping headers %s", *strip)
 	log.WithFields(log.Fields{"port": *port}).Infof("Listening on %s", *port)
@@ -111,7 +116,7 @@ func main() {
 		http.ListenAndServe(*port, &handler.Handler{
 			ProxyClient: &handler.ProxyClient{
 				Signer:              signer,
-				Client:              http.DefaultClient,
+				Client:              client,
 				StripRequestHeaders: *strip,
 				SigningNameOverride: *signingNameOverride,
 				HostOverride:        *hostOverride,


### PR DESCRIPTION
*Issue #, if available:*
- #15 

*Description of changes:*
This addresses the issue where a signed response may be a redirect.

The internal redirects made this unusable with Elasticsearch Service's kibana endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
