### PR TITLE
Add --no-verify-ssl option

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
     "os"
     "strconv"
     "time"
+    "crypto/tls"
 
     "aws-sigv4-proxy/handler"
     "github.com/aws/aws-sdk-go/aws/credentials"
@@ -38,6 +39,7 @@ var (
 	signingNameOverride = kingpin.Flag("name", "AWS Service to sign for").String();
 	hostOverride = kingpin.Flag("host", "Host to proxy to").String();
 	regionOverride = kingpin.Flag("region", "AWS region to sign for").String();
+	disableSSLVerification = kingpin.Flag("no-verify-ssl", "Disable peer SSL certificate validation").Bool()
 )
 
 func main() {
@@ -52,6 +54,11 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
+
+	if *disableSSLVerification {
+		log.Warn("Peer SSL Certificate validation is DISABLED")
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 
 	var credentials *credentials.Credentials
 	if *roleArn != "" {


### PR DESCRIPTION
**Description of changes:**

This adds the option to disable peer SSL certificate validation. This may be required in some corporate network scenarios, or with certain VPC Endpoints for specific AWS services.

**Isn't this bad?**
Yes, it is. You should only use this option if you really know you need to.

Unfortunately, this options is currently required in order to use the VPC Endpoints for Amazon Managed Service for Prometheus, as these do not support private DNS names at this time.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
