### PR TITLE
Transparently forward upstream response

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -144,10 +144,5 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	if log.GetLevel() == log.DebugLevel && resp.StatusCode >= 400 {
-		b, _ := ioutil.ReadAll(resp.Body)
-		log.WithField("message", string(b)).Error("error proxying request")
-	}
-
 	return resp, nil
 }


### PR DESCRIPTION
Modify `ProxyClient` to transparently pass through the upstream response, as-is, like a reverse proxy.

Usually with a proxy, you want to see everything (errors and all) as though you were talking to the upstream directly, and the role of this proxy is just to sign requests on behalf of the caller. Otherwise, the 4XXs and 5XXs the caller could normally see and act on get silently dropped and the connection closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
