### PR TITLE
Add options to have finer grained control on what to log

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,12 +35,13 @@ type Client interface {
 
 // ProxyClient implements the Client interface
 type ProxyClient struct {
-	Signer *v4.Signer
-	Client Client
+	Signer              *v4.Signer
+	Client              Client
 	StripRequestHeaders []string
 	SigningNameOverride string
-	HostOverride string
-	RegionOverride string
+	HostOverride        string
+	RegionOverride      string
+	LogFailedRequest    bool
 }
 
 func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoint) error {
@@ -144,9 +145,16 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	if log.GetLevel() == log.DebugLevel && resp.StatusCode >= 400 {
+	if (p.LogFailedRequest || log.GetLevel() == log.DebugLevel) && resp.StatusCode >= 400 {
 		b, _ := ioutil.ReadAll(resp.Body)
-		log.WithField("message", string(b)).Error("error proxying request")
+		log.WithField("request", fmt.Sprintf("%s %s", proxyReq.Method, proxyReq.URL)).
+			WithField("status_code", resp.StatusCode).
+			WithField("message", string(b)).
+			Error("error proxying request")
+
+		// Need to "reset" the response body because we consumed the stream above, otherwise empty body
+		// returned to the caller.
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 	}
 
 	return resp, nil

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -152,8 +152,8 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 			WithField("message", string(b)).
 			Error("error proxying request")
 
-		// Need to "reset" the response body because we consumed the stream above, otherwise empty body
-		// returned to the caller.
+		// Need to "reset" the response body because we consumed the stream above, otherwise caller will
+		// get empty body.
 		resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 	}
 

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 type awsLoggerAdapter struct {
 }
 
+// Log implements aws.Logger.Log
 func (awsLoggerAdapter) Log(args ...interface{}) {
 	log.Info(args...)
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ type awsLoggerAdapter struct {
 }
 
 func (awsLoggerAdapter) Log(args ...interface{}) {
-	log.Info(args)
+	log.Info(args...)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	debug                  = kingpin.Flag("verbose", "Enable additional logging, implies all the log-* options").Short('v').Bool()
-	logFailedResponse      = kingpin.Flag("log-failed-request", "Log 4xx and 5xx response body").Bool()
+	logFailedResponse      = kingpin.Flag("log-failed-requests", "Log 4xx and 5xx response body").Bool()
 	logSinging             = kingpin.Flag("log-signing-process", "Log sigv4 signing process").Bool()
 	port                   = kingpin.Flag("port", "Port to serve http on").Default(":8080").String()
 	strip                  = kingpin.Flag("strip", "Headers to strip from incoming request").Short('s').Strings()

--- a/main.go
+++ b/main.go
@@ -29,14 +29,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
-	debug                  = kingpin.Flag("verbose", "enable additional logging").Short('v').Bool()
-	port                   = kingpin.Flag("port", "port to serve http on").Default(":8080").String()
+	debug                  = kingpin.Flag("verbose", "enable additional logging, implies log-failed-request").Short('v').Bool()
+	logFailedResponse      = kingpin.Flag("log-failed-request", "Print 4xx and 5xx response body").Bool()
+	port                   = kingpin.Flag("port", "Port to serve http on").Default(":8080").String()
 	strip                  = kingpin.Flag("strip", "Headers to strip from incoming request").Short('s').Strings()
 	roleArn                = kingpin.Flag("role-arn", "Amazon Resource Name (ARN) of the role to assume").String()
 	signingNameOverride    = kingpin.Flag("name", "AWS Service to sign for").String()
@@ -101,6 +102,7 @@ func main() {
 				SigningNameOverride: *signingNameOverride,
 				HostOverride:        *hostOverride,
 				RegionOverride:      *regionOverride,
+				LogFailedRequest:    *logFailedResponse,
 			},
 		}),
 	)


### PR DESCRIPTION
*Description of changes:*

The `-v` option logs too much. This change provides some command line flags to let the user have finer grained control on what is logged. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
