### PR TITLE
Correctly detect API Gateway (execute-api) and OpenSearch requests

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -68,6 +68,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			handler: &Handler{
 				ProxyClient: &mockProxyClient{
 					Response: &http.Response{
+						StatusCode: http.StatusOK,
 						Header: http.Header{
 							"test": []string{"header"},
 						},


### PR DESCRIPTION
*Description of changes:*

This change:
1) Fixes an issue where api gateway (execute-api) and OpenSearch (elasticsearch service) requests could not be autodetected. Without this change they would fail with: 
```unable to proxy request - unable to determine service from host: abcdef.execute-api.us-west-2.amazonaws.com```.
This change adds a regex to extract the region and service from these requests.

2) Refactors proxy_client.go and improves testing. This factors out proxyURL and ResolvedEndpoint construction from `ProxyClient`s `Do` function so they can be tested, and adds tests for them.

3) Fixes a handler test that was failing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.