### PR TITLE
add managed prometheus + workspace endpoints support

### DIFF
--- a/handler/aws.go
+++ b/handler/aws.go
@@ -47,6 +47,14 @@ func init() {
 		host := fmt.Sprintf("%s.es.amazonaws.com", region)
 		services[host] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host), SigningMethod: "v4", SigningRegion: region, SigningName: "es", PartitionID: "aws"}
 	}
+	// Add managed prometheus + workspace endpoints
+	for region := range endpoints.AwsPartition().Regions() {
+		host_aps := fmt.Sprintf("aps.%s.amazonaws.com", region)
+		services[host_aps] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host_aps), SigningMethod: "v4", SigningRegion: region, SigningName: "aps", PartitionID: "aws"}
+
+		host_apsws := fmt.Sprintf("aps-workspaces.%s.amazonaws.com", region)
+		services[host_apsws] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host_apsws), SigningMethod: "v4", SigningRegion: region, SigningName: "aps", PartitionID: "aws"}
+	}
 }
 
 func determineAWSServiceFromHost(host string) *endpoints.ResolvedEndpoint {

--- a/handler/aws.go
+++ b/handler/aws.go
@@ -49,11 +49,11 @@ func init() {
 	}
 	// Add managed prometheus + workspace endpoints
 	for region := range endpoints.AwsPartition().Regions() {
-		host_aps := fmt.Sprintf("aps.%s.amazonaws.com", region)
-		services[host_aps] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host_aps), SigningMethod: "v4", SigningRegion: region, SigningName: "aps", PartitionID: "aws"}
+		hostAps := fmt.Sprintf("aps.%s.amazonaws.com", region)
+		services[hostAps] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", hostAps), SigningMethod: "v4", SigningRegion: region, SigningName: "aps", PartitionID: "aws"}
 
-		host_apsws := fmt.Sprintf("aps-workspaces.%s.amazonaws.com", region)
-		services[host_apsws] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", host_apsws), SigningMethod: "v4", SigningRegion: region, SigningName: "aps", PartitionID: "aws"}
+		hostApsws := fmt.Sprintf("aps-workspaces.%s.amazonaws.com", region)
+		services[hostApsws] = endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", hostApsws), SigningMethod: "v4", SigningRegion: region, SigningName: "aps", PartitionID: "aws"}
 	}
 }
 


### PR DESCRIPTION
fix the issue when prometheus workspace access, it will show the error of   `unable to proxy request - unable to determine service from host: aps-workspaces.REGION.amazonaws.com` 

*Description of changes:*
add explicit mapping for aps-workspaces to aps with sigv4 support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
