### PR TITLE
Disable V4 signer URI escaping for S3 requests

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -56,6 +56,17 @@ func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoin
 		body = bytes.NewReader(b)
 	}
 
+	// S3 service should not have any escaping applied.
+	// https://github.com/aws/aws-sdk-go/blob/main/aws/signer/v4/v4.go#L467-L470
+        if (service.SigningName == "s3") {
+		p.Signer.DisableURIPathEscaping = true
+
+		// Enable URI escaping for subsequent calls.
+		defer func() {
+			p.Signer.DisableURIPathEscaping = false
+		}()
+	}
+
 	var err error
 	switch service.SigningMethod {
 	case "v4", "s3v4":


### PR DESCRIPTION
*Issue #, if available:*
Today, making S3 requests with S3 location containing space characters like space, hash fails with 403 Authentication error. This is because V4 signer uri escapes the request uri. In case of S3 request, URI is already escaped in the request.

```
curl -s -H 'host: s3.amazonaws.com' http://localhost:8080/aws-sigv4-proxy-testing-bucket/hello%20world.txt
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>ASIAR57VPVSXXOTHTCBR</AWSAccessKeyId><StringToSign>AWS4-HMAC-SHA256
20220916T202400Z
20220916/us-east-1/s3/aws4_request

```

*Description of changes:*
In [V4 signer](https://github.com/aws/aws-sdk-go/blob/main/aws/signer/v4/v4.go#L467-L470), URI escaping is disabled for S3 request. Adding the same change here.

*Tests*
* Test listing the bucket
```
curl -s -H 'host: s3.amazonaws.com' http://localhost:8080/aws-sigv4-proxy-testing-bucket
<?xml version="1.0" encoding="UTF-8"?>
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>aws-sigv4-proxy-testing-bucket</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>hello world.txt</Key><LastModified>2022-09-16T19:31:38.000Z</LastModified><ETag>&quot;6f5902ac237024bdd0c176cb93063dc4&quot;</ETag><Size>12</Size><Owner><ID>3c221acdfcdc3606ac563c1da8c8031d7c93454b0241a877bceb3d613743a3f8</ID><DisplayName>aws-analytics-services-editors+desktop</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>hello_world.txt</Key><LastModified>2022-09-16T19:31:38.000Z</LastModified><ETag>&quot;6f5902ac237024bdd0c176cb93063dc4&quot;</ETag><Size>12</Size><Owner><ID>3c221acdfcdc3606ac563c1da8c8031d7c93454b0241a877bceb3d613743a3f8</ID><DisplayName>aws-analytics-services-editors+desktop</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
```

* Test getting an object with underscore which works today.
```
curl -s -H 'host: s3.amazonaws.com' http://localhost:8080/aws-sigv4-proxy-testing-bucket/hello_world.txt
hello world
```
* Test getting an object with space in the uri

```
curl -s -H 'host: s3.amazonaws.com' http://localhost:8080/aws-sigv4-proxy-testing-bucket/hello%20world.txt
hello world
```

* Test API gateway
```
curl -s -H 'host: sqs.us-west-2.amazonaws.com' 'http://localhost:8080/133121944751/<name>?Action=SendMessage&MessageBody=example'
<?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>50620804-3ebd-49c5-ad2e-4a9893925366</MessageId><MD5OfMessageBody>1a79a4d60de6718e8e5b326e338ae533</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>210f6a3f-e193-56ab-a9d0-31a13a0a60e3</RequestId></ResponseMetadata></SendMessageResponse>(base) b0f1d854578d:aws-sigv4-proxy
```

* Run golang tests
```
/usr/local/go/bin/go tool test2json -t /private/var/folders/gr/sb6mgq79003979_0yng82y9w0000gr/T/GoLand/___1go_test_aws_sigv4_proxy_handler.test -test.v -test.paniconexit0
=== RUN   TestHandler_ServeHTTP
=== RUN   TestHandler_ServeHTTP/responds_with_502_if_proxy_request_fails
time="2022-09-16T13:30:16-07:00" level=error msg="unable to proxy request" error="mockProxyClient.Do failed"
=== RUN   TestHandler_ServeHTTP/responds_with_proxied_response_if_everything_is_👍
--- PASS: TestHandler_ServeHTTP (0.00s)
    --- PASS: TestHandler_ServeHTTP/responds_with_502_if_proxy_request_fails (0.00s)
    --- PASS: TestHandler_ServeHTTP/responds_with_proxied_response_if_everything_is_👍 (0.00s)
=== RUN   TestProxyClient_Do
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_build_new_request
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_determine_service_name
=== RUN   TestProxyClient_Do/should_use_SignNameOverride_and_RegionOverride_if_provided
=== RUN   TestProxyClient_Do/should_use_HostOverride_if_provided
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_sign_request
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_sign_request#01
=== RUN   TestProxyClient_Do/should_fail_if_request_to_target_host_fails
=== RUN   TestProxyClient_Do/should_return_request_when_everything_👍_(presign_codepath)
=== RUN   TestProxyClient_Do/should_return_request_when_everything_👍
=== RUN   TestProxyClient_Do/should_propagate_non-zero_content_length
=== RUN   TestProxyClient_Do/should_propagate_content_length_when_it's_zero
--- PASS: TestProxyClient_Do (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_build_new_request (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_determine_service_name (0.00s)
    --- PASS: TestProxyClient_Do/should_use_SignNameOverride_and_RegionOverride_if_provided (0.00s)
    --- PASS: TestProxyClient_Do/should_use_HostOverride_if_provided (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_sign_request (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_sign_request#01 (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_request_to_target_host_fails (0.00s)
    --- PASS: TestProxyClient_Do/should_return_request_when_everything_👍_(presign_codepath) (0.00s)
    --- PASS: TestProxyClient_Do/should_return_request_when_everything_👍 (0.00s)
    --- PASS: TestProxyClient_Do/should_propagate_non-zero_content_length (0.00s)
    --- PASS: TestProxyClient_Do/should_propagate_content_length_when_it's_zero (0.00s)
PASS

/usr/local/go/bin/go tool test2json -t /private/var/folders/gr/sb6mgq79003979_0yng82y9w0000gr/T/GoLand/___1go_test_aws_sigv4_proxy_handler.test -test.v -test.paniconexit0
=== RUN   TestHandler_ServeHTTP
=== RUN   TestHandler_ServeHTTP/responds_with_502_if_proxy_request_fails
time="2022-09-16T13:30:35-07:00" level=error msg="unable to proxy request" error="mockProxyClient.Do failed"
=== RUN   TestHandler_ServeHTTP/responds_with_proxied_response_if_everything_is_👍
--- PASS: TestHandler_ServeHTTP (0.00s)
    --- PASS: TestHandler_ServeHTTP/responds_with_502_if_proxy_request_fails (0.00s)
    --- PASS: TestHandler_ServeHTTP/responds_with_proxied_response_if_everything_is_👍 (0.00s)
=== RUN   TestProxyClient_Do
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_build_new_request
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_determine_service_name
=== RUN   TestProxyClient_Do/should_use_SignNameOverride_and_RegionOverride_if_provided
=== RUN   TestProxyClient_Do/should_use_HostOverride_if_provided
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_sign_request
=== RUN   TestProxyClient_Do/should_fail_if_unable_to_sign_request#01
=== RUN   TestProxyClient_Do/should_fail_if_request_to_target_host_fails
=== RUN   TestProxyClient_Do/should_return_request_when_everything_👍_(presign_codepath)
=== RUN   TestProxyClient_Do/should_return_request_when_everything_👍
=== RUN   TestProxyClient_Do/should_propagate_non-zero_content_length
=== RUN   TestProxyClient_Do/should_propagate_content_length_when_it's_zero
--- PASS: TestProxyClient_Do (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_build_new_request (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_determine_service_name (0.00s)
    --- PASS: TestProxyClient_Do/should_use_SignNameOverride_and_RegionOverride_if_provided (0.00s)
    --- PASS: TestProxyClient_Do/should_use_HostOverride_if_provided (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_sign_request (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_unable_to_sign_request#01 (0.00s)
    --- PASS: TestProxyClient_Do/should_fail_if_request_to_target_host_fails (0.00s)
    --- PASS: TestProxyClient_Do/should_return_request_when_everything_👍_(presign_codepath) (0.00s)
    --- PASS: TestProxyClient_Do/should_return_request_when_everything_👍 (0.00s)
    --- PASS: TestProxyClient_Do/should_propagate_non-zero_content_length (0.00s)
    --- PASS: TestProxyClient_Do/should_propagate_content_length_when_it's_zero (0.00s)
PASS
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
