### PR TITLE
Feature :: Signing HOST override

### DIFF
--- a/cmd/aws-sigv4-proxy/main.go
+++ b/cmd/aws-sigv4-proxy/main.go
@@ -42,6 +42,7 @@ var (
 	strip                  = kingpin.Flag("strip", "Headers to strip from incoming request").Short('s').Strings()
 	roleArn                = kingpin.Flag("role-arn", "Amazon Resource Name (ARN) of the role to assume").String()
 	signingNameOverride    = kingpin.Flag("name", "AWS Service to sign for").String()
+	signingHostOverride    = kingpin.Flag("sign-host", "Host to sign for").String()
 	hostOverride           = kingpin.Flag("host", "Host to proxy to").String()
 	regionOverride         = kingpin.Flag("region", "AWS region to sign for").String()
 	disableSSLVerification = kingpin.Flag("no-verify-ssl", "Disable peer SSL certificate validation").Bool()
@@ -124,6 +125,7 @@ func main() {
 				Client:              client,
 				StripRequestHeaders: *strip,
 				SigningNameOverride: *signingNameOverride,
+				SigningHostOverride: *signingHostOverride,
 				HostOverride:        *hostOverride,
 				RegionOverride:      *regionOverride,
 				LogFailedRequest:    *logFailedResponse,

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -39,6 +39,7 @@ type ProxyClient struct {
 	Client              Client
 	StripRequestHeaders []string
 	SigningNameOverride string
+	SigningHostOverride string
 	HostOverride        string
 	RegionOverride      string
 	LogFailedRequest    bool
@@ -124,6 +125,9 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	var service *endpoints.ResolvedEndpoint
+	if p.SigningHostOverride != "" {
+	    proxyReq.Host = p.SigningHostOverride
+	}
 	if p.SigningNameOverride != "" && p.RegionOverride != "" {
 		service = &endpoints.ResolvedEndpoint{URL: fmt.Sprintf("https://%s", proxyURL.Host), SigningMethod: "v4", SigningRegion: p.RegionOverride, SigningName: p.SigningNameOverride}
 	} else {


### PR DESCRIPTION
## Issue, if available:
Accessing OpenSearch domain hosted within VPC requires different `HOST` for signature generation than the one request is passed to (see description of changes for more).

This way valid response is received instead of
```
{
    "message": "The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.\n\nThe Canonical String for this request should have been\n'GET\n/_snapshot\n\nhost:vpc-__NAME__.eu-west-1.es.amazonaws.com\nx-amz-date:20221031T113014Z\nx-amz-security-token:__TOKEN__\n\nhost;x-amz-date;x-amz-security-token\n__TOKEN__'\n\nThe String-to-Sign should have been\n'AWS4-HMAC-SHA256\n20221031T113014Z\n20221031/eu-west-1/es/aws4_request\n__REQUEST_ID__'\n"
}
```

## Description of changes:
Adds new argument `sign-host` used for Signature generation.

Following changes allows to:
1. start `aws-sigv4-proxy` docker container via command like this:
   ```
   docker run --rm -ti \
        -v ~/.aws:/root/.aws \
        --network=bridge \
        -p 8080:8080 \
        -e "AWS_SDK_LOAD_CONFIG=true" \
        -e "AWS_PROFILE=default" \
        aws-sigv4-proxy:signing-host-override \
                --verbose --log-failed-requests --log-signing-process --no-verify-ssl \
                --name es --region eu-west-1 \
                --host host.docker.internal:4443 \
                --sign-host eu-west-1.es.amazonaws.com
   ```
2. route traffic OpenSearch via bastion host with ssh tunnel as no root on port > 1000
   ```
    ssh \
	-4 \
	-o BatchMode="yes" \
	-o StrictHostKeyChecking="no" \
	-o ProxyCommand="aws ssm start-session --target %h --region eu-west-1 --document-name AWS-StartSSHSession --parameters portNumber=%p" \
	-i /Users/user/.ssh/id_rsa ubuntu@i-bastion-host \
	-L 4443:vpc-private-domain-name.eu-west-1.es.amazonaws.com:443 \
	-N
   ```
3. access dashboard via `http://localhost:8080/_dashboards/app/home#/tutorial_directory` URL

![image](https://user-images.githubusercontent.com/15868089/199000224-e91b469f-23c9-41c2-a20a-079726319ba2.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
