### PR TITLE
Adding support to specify HTTP/HTTPS schema

### DIFF
--- a/cmd/aws-sigv4-proxy/main.go
+++ b/cmd/aws-sigv4-proxy/main.go
@@ -47,6 +47,7 @@ var (
 	regionOverride         = kingpin.Flag("region", "AWS region to sign for").String()
 	disableSSLVerification = kingpin.Flag("no-verify-ssl", "Disable peer SSL certificate validation").Bool()
 	idleConnTimeout        = kingpin.Flag("transport.idle-conn-timeout", "Idle timeout to the upstream service").Default("40s").Duration()
+	schemeOverride         = kingpin.Flag("scheme", "Protocol to proxy with").String()
 )
 
 type awsLoggerAdapter struct {
@@ -129,6 +130,7 @@ func main() {
 				HostOverride:        *hostOverride,
 				RegionOverride:      *regionOverride,
 				LogFailedRequest:    *logFailedResponse,
+				SchemeOverride:      *schemeOverride,
 			},
 		}),
 	)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When using the AWS SigV4 Proxy with Lattice, there are often use cases when the Lattice service is not secured using HTTPS. Hence, it would suffice to use HTTP. The proxy was previously was only using HTTPS. Added an argument to indicate if it should use HTTP instead. There is a corresponding change made to the AWS SigV4 Admission Controller to inject this argument based on an annotation on the target workload.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
