### PR TITLE
Include s3 object lambda for uri path escaping disablement

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -60,7 +60,7 @@ func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoin
 
 	// S3 service should not have any escaping applied.
 	// https://github.com/aws/aws-sdk-go/blob/main/aws/signer/v4/v4.go#L467-L470
-	if service.SigningName == "s3" {
+	if service.SigningName == "s3" || service.SigningName == "s3-object-lambda" {
 		p.Signer.DisableURIPathEscaping = true
 
 		// Enable URI escaping for subsequent calls.


### PR DESCRIPTION
Extending of https://github.com/aws/aws-sdk-go/blob/main/aws/signer/v4/v4.go#L467-L470
Includes s3 object lambda as a service for DisableURIPathEscaping.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
