### PR TITLE
Add support for duplicating headers to X-Original- prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode
 .idea/
+
+# binary
+aws-sigv4-proxy

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ When running the Proxy, the following flags can be used (none are required) :
 | `unsigned-payload`            | Boolean  | Prevent signing of the payload"                          | `False` |
 | `port`                        | String   | Port to serve http on                                    | `8080`  |
 | `strip` or `s`                | String   | Headers to strip from incoming request                   | None    |
+| `duplicate-headers`           | String   | Duplicate headers to an X-Original- prefix name          | None    |
 | `role-arn`                    | String   | Amazon Resource Name (ARN) of the role to assume         | None    |
 | `name`                        | String   | AWS Service to sign for                                  | None    |
 | `sign-host`                   | String   | Host to sign for                                         | None    |
@@ -89,6 +90,17 @@ docker run --rm -ti \
   -e 'AWS_SDK_LOAD_CONFIG=true' \
   -e 'AWS_PROFILE=<SOME PROFILE>' \
   aws-sigv4-proxy -v -s Authorization
+```
+
+Running the service and preserving the original Authorization header as X-Original-Authorization (useful because Authorization header will be overwritten.)
+
+```sh
+docker run --rm -ti \
+  -v ~/.aws:/root/.aws \
+  -p 8080:8080 \
+  -e 'AWS_SDK_LOAD_CONFIG=true' \
+  -e 'AWS_PROFILE=<SOME PROFILE>' \
+  aws-sigv4-proxy -v --duplicate-headers Authorization
 ```
 
 Running the service with Assume Role to use temporary credentials

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -194,8 +194,13 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 	// Duplicate the header value for any headers specified into a new header
 	// with an "X-Original-" prefix.
 	for _, header := range p.DuplicateRequestHeaders {
-		log.WithField("DuplicateHeader", string(header)).Debug("Duplicate Header to X-Original-* Prefix:")
 		headerValue := req.Header.Get(header)
+		if headerValue == "" {
+			log.WithField("DuplicateHeader", string(header)).Debug("Header empty, will not duplicate:")
+			continue
+		}
+
+		log.WithField("DuplicateHeader", string(header)).Debug("Duplicate Header to X-Original-* Prefix:")
 		newHeaderName := fmt.Sprintf("X-Original-%s", header)
 		proxyReq.Header.Set(newHeaderName, headerValue)
 	}

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -197,7 +197,7 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 		log.WithField("DuplicateHeader", string(header)).Debug("Duplicate Header to X-Original-* Prefix:")
 		headerValue := req.Header.Get(header)
 		newHeaderName := fmt.Sprintf("X-Original-%s", header)
-		req.Header.Set(newHeaderName, headerValue)
+		proxyReq.Header.Set(newHeaderName, headerValue)
 	}
 
 	// Add origin headers after request is signed (no overwrite)

--- a/handler/proxy_client_test.go
+++ b/handler/proxy_client_test.go
@@ -388,9 +388,33 @@ func TestProxyClient_Do(t *testing.T) {
 				request: &http.Request{
 					Host: "execute-api.us-west-2.amazonaws.com",
 					Header: http.Header{
-						"Authorization":            []string{"customValue"},
 						"X-Original-Authorization": []string{"customValue"},
 						"User-Agent":               []string{"customAgent"},
+					},
+				},
+			},
+		},
+		{
+			name: "should not duplicate empty headers with prefix",
+			request: &http.Request{
+				Method: "GET",
+				URL:    &url.URL{},
+				Host:   "execute-api.us-west-2.amazonaws.com",
+				Body:   nil,
+			},
+			proxyClient: &ProxyClient{
+				Signer:                  v4.NewSigner(credentials.NewCredentials(&mockProvider{})),
+				Client:                  &mockHTTPClient{},
+				DuplicateRequestHeaders: []string{"NonExistentHeader"},
+			},
+			want: &want{
+				resp: &http.Response{},
+				err:  nil,
+				request: &http.Request{
+					Host: "execute-api.us-west-2.amazonaws.com",
+					Header: http.Header{
+						// Ensure headers are not present
+						"X-Original-NonExistentHeader": nil,
 					},
 				},
 			},
@@ -404,14 +428,17 @@ func TestProxyClient_Do(t *testing.T) {
 
 			assert.Equal(t, tt.want.resp, resp)
 			assert.Equal(t, tt.want.err, err)
-			if tt.request.Header != nil && tt.want.request.Header != nil {
-				assert.Equal(t, tt.want.request.Header, tt.request.Header)
-			}
 
 			proxyRequest := tt.proxyClient.Client.(*mockHTTPClient).Request
+
 			assert.True(t, verifyRequest(proxyRequest, tt.want.request))
 			if proxyRequest == nil {
 				return
+			}
+
+			// Ensure specific headers are propagated (or not in certain cases) to the proxy request
+			for kk, vv := range tt.want.request.Header {
+				assert.Equal(t, vv, proxyRequest.Header[kk])
 			}
 
 			// Ensure encoding is propagated to the proxy request.


### PR DESCRIPTION
Addresses #162 

*Description of changes:*
- Allows duplicating headers such as the `Authorization` header to a `X-Original-Authorization` header name to preserve them because the `Authorization` header will be overwritten by this proxy.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
