### PR TITLE
Enable AWS SSO support

### DIFF
--- a/cmd/aws-sigv4-proxy/main.go
+++ b/cmd/aws-sigv4-proxy/main.go
@@ -67,6 +67,10 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
+	sessionOptions := session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}
+
 	sessionConfig := aws.Config{}
 	if v := os.Getenv("AWS_STS_REGIONAL_ENDPOINTS"); len(v) == 0 {
 		sessionConfig.STSRegionalEndpoint = endpoints.RegionalSTSEndpoint
@@ -74,7 +78,8 @@ func main() {
 
 	sessionConfig.CredentialsChainVerboseErrors = aws.Bool(shouldLogSigning())
 
-	session, err := session.NewSession(&sessionConfig)
+	sessionOptions.Config.MergeIn(&sessionConfig)
+	session, err := session.NewSessionWithOptions(sessionOptions)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-sigv4-proxy/issues/108

Description: Set session.Options.SharedConfigState to session.SharedConfigEnable to enable aws sso support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
