### PR TITLE
Fix issue 185 -  request cannot rewind during retry

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -141,6 +141,10 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 		log.WithField("request", string(initialReqDump)).Debug("Initial request dump:")
 	}
 
+	// Save the request body into memory so that it's rewindable during retry.
+	// See https://github.com/awslabs/aws-sigv4-proxy/issues/185
+	// This may increase memory demand, but the demand should be ok for most cases. If there
+	// are cases proven to be very problematic, we can consider adding a flag to disable this.
 	proxyReqBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -18,6 +18,7 @@ package handler
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
@@ -140,7 +141,12 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 		log.WithField("request", string(initialReqDump)).Debug("Initial request dump:")
 	}
 
-	proxyReq, err := http.NewRequest(req.Method, proxyURL.String(), req.Body)
+	proxyReqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyReq, err := http.NewRequest(req.Method, proxyURL.String(), bytes.NewReader(proxyReqBody))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sigv4-proxy/issues/185

*Description of changes:*
Need to store the upstream request body into memory so we can retry in case of retriable networking error to down stream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
