### PR TITLE
Allow stripping of headers and query parameters using prefix string

### DIFF
--- a/cmd/aws-sigv4-proxy/main.go
+++ b/cmd/aws-sigv4-proxy/main.go
@@ -39,7 +39,8 @@ var (
 	logFailedResponse      = kingpin.Flag("log-failed-requests", "Log 4xx and 5xx response body").Bool()
 	logSinging             = kingpin.Flag("log-signing-process", "Log sigv4 signing process").Bool()
 	port                   = kingpin.Flag("port", "Port to serve http on").Default(":8080").String()
-	strip                  = kingpin.Flag("strip", "Headers to strip from incoming request").Short('s').Strings()
+	strip                  = kingpin.Flag("strip", "Headers to strip from incoming request. Use wildcard suffix * to match header key prefix").Short('s').Strings()
+	stripParam             = kingpin.Flag("stripParam", "Query parameters to strip from incoming request. Use wildcard suffix '*' to match parameter prefix").Strings()
 	duplicateHeaders       = kingpin.Flag("duplicate-headers", "Duplicate headers to an X-Original- prefix name").Strings()
 	roleArn                = kingpin.Flag("role-arn", "Amazon Resource Name (ARN) of the role to assume").String()
 	signingNameOverride    = kingpin.Flag("name", "AWS Service to sign for").String()
@@ -120,6 +121,7 @@ func main() {
 	}
 
 	log.WithFields(log.Fields{"StripHeaders": *strip}).Infof("Stripping headers %s", *strip)
+	log.WithFields(log.Fields{"StripParams": *stripParam}).Infof("Stripping query parameters %s", *stripParam)
 	log.WithFields(log.Fields{"DuplicateHeaders": *duplicateHeaders}).Infof("Duplicating headers %s", *duplicateHeaders)
 	log.WithFields(log.Fields{"port": *port}).Infof("Listening on %s", *port)
 
@@ -129,6 +131,7 @@ func main() {
 				Signer:                  signer,
 				Client:                  client,
 				StripRequestHeaders:     *strip,
+				StripRequestQueryParams: *stripParam,
 				DuplicateRequestHeaders: *duplicateHeaders,
 				SigningNameOverride:     *signingNameOverride,
 				SigningHostOverride:     *signingHostOverride,

--- a/handler/proxy_client_test.go
+++ b/handler/proxy_client_test.go
@@ -395,17 +395,18 @@ func TestProxyClient_Do(t *testing.T) {
 			},
 		},
 		{
-			name: "should not duplicate empty headers with prefix",
+			name: "should strip request headers",
 			request: &http.Request{
 				Method: "GET",
 				URL:    &url.URL{},
 				Host:   "execute-api.us-west-2.amazonaws.com",
+				Header: http.Header{"StripMePlease": []string{"prettyplease"}},
 				Body:   nil,
 			},
 			proxyClient: &ProxyClient{
-				Signer:                  v4.NewSigner(credentials.NewCredentials(&mockProvider{})),
-				Client:                  &mockHTTPClient{},
-				DuplicateRequestHeaders: []string{"NonExistentHeader"},
+				Signer:              v4.NewSigner(credentials.NewCredentials(&mockProvider{})),
+				Client:              &mockHTTPClient{},
+				StripRequestHeaders: []string{"StripMePlease"},
 			},
 			want: &want{
 				resp: &http.Response{},
@@ -414,7 +415,7 @@ func TestProxyClient_Do(t *testing.T) {
 					Host: "execute-api.us-west-2.amazonaws.com",
 					Header: http.Header{
 						// Ensure headers are not present
-						"X-Original-NonExistentHeader": nil,
+						"StripMePlease": nil,
 					},
 				},
 			},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add `strip-header` and `strip-param` flags which allow either exact match or prefix match (by way of trailing asterisk).
- deprecate `strip` flag
- add tests for header, param stripping
- fix check for non-existent headers in tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
