### PR TITLE
Add Support for Custom Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,25 @@ docker run --rm -ti \
 ### Configuration
 
 When running the Proxy, the following flags can be used (none are required) :
-
-| Flag (or short form)          | Type     | Description                                              | Default |
-|-------------------------------|----------|----------------------------------------------------------|---------|
-| `verbose` or `v`              | Boolean  | Enable additional logging, implies all the log-* options | `False` |
-| `log-failed-requests`         | Boolean  | Log 4xx and 5xx response body                            | `False` |
-| `log-signing-process`         | Boolean  | Log sigv4 signing process                                | `False` |
-| `unsigned-payload`            | Boolean  | Prevent signing of the payload"                          | `False` |
-| `port`                        | String   | Port to serve http on                                    | `8080`  |
-| `strip` or `s`                | String   | Headers to strip from incoming request                   | None    |
-| `duplicate-headers`           | String   | Duplicate headers to an X-Original- prefix name          | None    |
-| `role-arn`                    | String   | Amazon Resource Name (ARN) of the role to assume         | None    |
-| `name`                        | String   | AWS Service to sign for                                  | None    |
-| `sign-host`                   | String   | Host to sign for                                         | None    |
-| `host`                        | String   | Host to proxy to                                         | None    |
-| `region`                      | String   | AWS region to sign for                                   | None    |
-| `upstream-url-scheme`         | String   | Protocol to proxy with                                   | https   |
-| `no-verify-ssl`               | Boolean  | Disable peer SSL certificate validation                  | `False` |
-| `transport.idle-conn-timeout` | Duration | Idle timeout to the upstream service                     | `40s`   |
+s", "
+| Flag (or short form)          | Type     | Description                                                | Default |
+|-------------------------------|----------|------------------------------------------------------------|---------|
+| `verbose` or `v`              | Boolean  | Enable additional logging, implies all the log-* options   | `False` |
+| `log-failed-requests`         | Boolean  | Log 4xx and 5xx response body                              | `False` |
+| `log-signing-process`         | Boolean  | Log sigv4 signing process                                  | `False` |
+| `unsigned-payload`            | Boolean  | Prevent signing of the payload"                            | `False` |
+| `port`                        | String   | Port to serve http on                                      | `8080`  |
+| `strip` or `s`                | String   | Headers to strip from incoming request                     | None    |
+| `custom-headers`              | String   | Comma-separated list of custom headers in key=value format | None    |
+| `duplicate-headers`           | String   | Duplicate headers to an X-Original- prefix name            | None    |
+| `role-arn`                    | String   | Amazon Resource Name (ARN) of the role to assume           | None    |
+| `name`                        | String   | AWS Service to sign for                                    | None    |
+| `sign-host`                   | String   | Host to sign for                                           | None    |
+| `host`                        | String   | Host to proxy to                                           | None    |
+| `region`                      | String   | AWS region to sign for                                     | None    |
+| `upstream-url-scheme`         | String   | Protocol to proxy with                                     | https   |
+| `no-verify-ssl`               | Boolean  | Disable peer SSL certificate validation                    | `False` |
+| `transport.idle-conn-timeout` | Duration | Idle timeout to the upstream service                       | `40s`   |
 
 ## Examples
 

--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -39,6 +39,7 @@ type ProxyClient struct {
 	Signer                  *v4.Signer
 	Client                  Client
 	StripRequestHeaders     []string
+	CustomHeaders           http.Header
 	DuplicateRequestHeaders []string
 	SigningNameOverride     string
 	SigningHostOverride     string
@@ -225,6 +226,9 @@ func (p *ProxyClient) Do(req *http.Request) (*http.Response, error) {
 
 	// Add origin headers after request is signed (no overwrite)
 	copyHeaderWithoutOverwrite(proxyReq.Header, req.Header)
+
+	// Add custom headers (no overwrite)
+	copyHeaderWithoutOverwrite(proxyReq.Header, p.CustomHeaders)
 
 	if log.GetLevel() == log.DebugLevel {
 		proxyReqDump, err := httputil.DumpRequest(proxyReq, true)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sigv4-proxy/issues/211
*Description of changes:*

The current implementation lacks the ability to add custom headers to HTTP requests, which can be useful for various purposes such as passing custom client information, or other metadata. This feature would enhance the flexibility and utility of the application by allowing users to specify additional headers as needed.

Introduce a new command-line flag `--custom-headers` that accepts a comma-separated list of headers in key=value format. The headers will be parsed and added to the HTTP request only if they do not already exist in the request, ensuring that the origin headers are not overridden.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
