### PR TITLE
Restore request body after reading in `sign` method

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -59,6 +59,7 @@ func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoin
 		}
 
 		body = bytes.NewReader(b)
+		req.Body = io.NopCloser(bytes.NewReader(b))
 	}
 
 	// S3 service should not have any escaping applied.


### PR DESCRIPTION
*Issue #, if available:*
#225

*Description of changes:*
The problem is the the `sign` method in ProxyClient reads the `req.Body` and that results in a closed reader.

When the request is actually send to the transport later, the body cannot be read and results in a body length of 0 which does not match the passed req.ContentLength.

We tried to write tests for this, but the tests are not fully matching the real world because:
* they use io.NopCloser
* they use a HTTP mock client that doesn't actually read the body to send to the proxy (makes sense, its a mock, but it's different than the actual implementation)

If you have advice how to test this properly, we're all ears. 