### PR TITLE
Chore: Update minimal golang version to 1.23.6 and use scratch base image

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ~1.22.4
+          go-version: ~1.23.6
 
       - name: Build
         run: |

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ~1.22.4
+          go-version: ~1.23.6
 
       - name: Build
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.4-alpine AS build
+FROM golang:1.23.6-alpine AS build
 
 RUN apk --update add \
       ca-certificates \
@@ -12,7 +12,7 @@ RUN go env -w GOPROXY=direct
 
 RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/aws-sigv4-proxy
 
-FROM alpine:3
+FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /aws-sigv4-proxy/aws-sigv4-proxy ./
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module aws-sigv4-proxy
 
-go 1.22.4
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6


### PR DESCRIPTION
*Description of changes:* 
* Update minimal golang version to 1.23.6
* Use scratch image for the docker image


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
