### PR TITLE
Add correct permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write # allow the workflow to create release notes
 
 env:
   AWS_PUBLIC_ECR_REGION: us-east-1


### PR DESCRIPTION
*Issue #, if available:* Release v1.10 was partially successful. https://github.com/awslabs/aws-sigv4-proxy/actions/runs/13292196756/job/37115506807

If failed to automatically publish the release notes. This CR fixes that based on the documentation https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
