### PR TITLE
Fix escaping of special characters in S3 URLs

### DIFF
--- a/handler/proxy_client.go
+++ b/handler/proxy_client.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	log "github.com/sirupsen/logrus"
 )
@@ -66,6 +67,8 @@ func (p *ProxyClient) sign(req *http.Request, service *endpoints.ResolvedEndpoin
 	if service.SigningName == "s3" || service.SigningName == "s3-object-lambda" {
 		p.Signer.DisableURIPathEscaping = true
 
+		req.URL.RawPath = rest.EscapePath(req.URL.Path, false)
+		
 		// Enable URI escaping for subsequent calls.
 		defer func() {
 			p.Signer.DisableURIPathEscaping = false


### PR DESCRIPTION
Escape URL RawPath for S3 requests. SIgner will use the unescaped URL, but the client will used the escaped RawPath. This ensures S3 URLs with special characters are reachable.

Fixes #11 #13 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
